### PR TITLE
feat(dependency-checker): Add Initializer.

### DIFF
--- a/includes/class-dependencychecker.php
+++ b/includes/class-dependencychecker.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * DependencyChecker class file.
+ * specific to Newspack functionality.
+ *
+ * @package Newspack\TecnaviaIntegration
+ */
+
+namespace Newspack\TecnaviaIntegration;
+
+// Check if needed functions exists - if not, require them.
+if ( ! function_exists( 'get_plugins' ) || ! function_exists( 'is_plugin_active' ) ) {
+	require_once ABSPATH . 'wp-admin/includes/plugin.php';
+}
+
+/**
+ * Provide functionality to check the plugin's dependencies on other plugin.
+ *
+ * @since 1.0
+ */
+class DependencyChecker {
+
+	const WOOCOMMERCE_PLUGIN              = 'woocommerce/woocommerce.php';
+	const WOOCOMMERCE_MEMBERSHIPS_PLUGIN  = 'woocommerce-memberships/woocommerce-memberships.php';
+	const WOOCOMMERCE_SUBSCRIPTION_PLUGIN = 'woocommerce-subscriptions/woocommerce-subscriptions.php';
+
+	/**
+	 * Check if plugin is installed by getting all plugins from the plugins dir.
+	 *
+	 * @param  string $plugin_slug Slug of the plugin to check for.
+	 * @return bool
+	 */
+	protected static function check_plugin_installed( $plugin_slug ): bool {
+		$installed_plugins = get_plugins();
+
+		return array_key_exists( $plugin_slug, $installed_plugins ) || in_array( $plugin_slug, $installed_plugins, true );
+	}
+
+	/**
+	 * Check if plugin is installed.
+	 *
+	 * @param  string $plugin_slug Slug of the plugin to check for.
+	 * @return bool
+	 */
+	protected static function check_plugin_active( $plugin_slug ): bool {
+		if ( is_plugin_active( $plugin_slug ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check whether 'WooCommerce Memberships' plugin is installed.
+	 *
+	 * @return bool Return true if plugin installed.
+	 */
+	public static function is_wc_installed(): bool {
+		if ( self::check_plugin_installed( self::WOOCOMMERCE_PLUGIN ) ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Check whether 'WooCommerce Memberships' plugin is active.
+	 *
+	 * @return bool Return true if plugin active.
+	 */
+	public static function is_wc_active(): bool {
+		if ( self::check_plugin_active( self::WOOCOMMERCE_PLUGIN ) ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Check whether 'WooCommerce Memberships' plugin is installed.
+	 *
+	 * @return bool Return true if plugin installed.
+	 */
+	public static function is_wc_memberships_installed(): bool {
+		if ( self::check_plugin_installed( self::WOOCOMMERCE_MEMBERSHIPS_PLUGIN ) ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Check whether 'WooCommerce Memberships' plugin is active.
+	 *
+	 * @return bool Return true if plugin active.
+	 */
+	public static function is_wc_memberships_active(): bool {
+		if ( self::check_plugin_active( self::WOOCOMMERCE_MEMBERSHIPS_PLUGIN ) ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Check whether 'WooCommerce Subscriptions' plugin is installed.
+	 *
+	 * @return bool Return true if plugin installed.
+	 */
+	public static function is_wc_subscriptions_installed(): bool {
+		if ( self::check_plugin_installed( self::WOOCOMMERCE_SUBSCRIPTION_PLUGIN ) ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Check whether 'WooCommerce Subscriptions' plugin is active.
+	 *
+	 * @return bool Return true if plugin active.
+	 */
+	public static function is_wc_subscriptions_active(): bool {
+		if ( self::check_plugin_active( self::WOOCOMMERCE_SUBSCRIPTION_PLUGIN ) ) {
+			return true;
+		}
+		return false;
+	}
+}

--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Newspack Tecnavia Integration Initializer.
+ *
+ * @package Newspack\TecnaviaIntegration
+ */
+
+namespace Newspack\TecnaviaIntegration;
+
+/**
+ * Class to handle the plugin initialization
+ */
+class Initializer {
+
+	/**
+	 * Runs the initialization.
+	 */
+	public static function init() {
+		// Setup Hooks & Filters.
+		add_action( 'admin_notices', array( __CLASS__, 'show_admin_notice__error' ) );
+	}
+
+	/**
+	 * Check and displays plugin specific notices when required.
+	 *
+	 * @return bool Return false on error.
+	 */
+	public static function has_valid_dependencies() {
+		if ( ! DependencyChecker::is_wc_installed()
+			|| ! DependencyChecker::is_wc_active()
+			|| ! DependencyChecker::is_wc_memberships_installed()
+			|| ! DependencyChecker::is_wc_memberships_active()
+			|| ! DependencyChecker::is_wc_subscriptions_installed()
+			|| ! DependencyChecker::is_wc_subscriptions_active()
+		) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Displays admin notice summarizing error.
+	 */
+	public static function show_admin_notice__error() {
+		$plugin_notice = '';
+		$allowed_html  = array(
+			'a' => array(
+				'href' => array(),
+			),
+			'b' => array(),
+		);
+
+		if ( ! DependencyChecker::is_wc_installed() ) {
+			$plugin_notice = '<b>Newspack Tecnavi Integration</b> plugin requires <b>WooCommerce</b> to be installed, active and configured.';
+		} elseif ( ! DependencyChecker::is_wc_active() ) {
+			$plugin_notice = '<b>Newspack Tecnavi Integration</b> plugin requires <b>WooCommerce</b> to be active. Open <a href="' . esc_url( admin_url( 'plugins.php?plugin_status=inactive' ) ) . '">Plugins Page</a>.';
+		} elseif ( ! DependencyChecker::is_wc_memberships_installed() ) {
+			$plugin_notice = '<b>Newspack Tecnavi Integration</b> plugin requires <b>WooCommerce Memberships</b> to be installed, active and configured.';
+		} elseif ( ! DependencyChecker::is_wc_memberships_active() ) {
+			$plugin_notice = '<b>Newspack Tecnavi Integration</b> plugin requires <b>WooCommerce Memberships</b> to be active. Open <a href="' . esc_url( admin_url( 'plugins.php?plugin_status=inactive' ) ) . '">Plugins Page</a>.';
+		} elseif ( ! DependencyChecker::is_wc_subscriptions_installed() ) {
+			$plugin_notice = '<b>Newspack Tecnavi Integration</b> plugin requires <b>WooCommerce Subscriptions</b> to be installed, active and configured.';
+		} elseif ( ! DependencyChecker::is_wc_subscriptions_active() ) {
+			$plugin_notice = '<b>Newspack Tecnavi Integration</b> plugin requires <b>WooCommerce Subscriptions</b> to be active. Open <a href="' . esc_url( admin_url( 'plugins.php?plugin_status=inactive' ) ) . '">Plugins Page</a>.';
+		}
+
+		if ( ! empty( $plugin_notice ) ) {
+			?>
+			<div class="notice notice-error">
+				<p>
+					<?php
+					echo wp_kses( $plugin_notice, $allowed_html );
+					?>
+				</p>
+			</div>
+			<?php
+		}
+	}
+}

--- a/newspack-tecnavia-integration.php
+++ b/newspack-tecnavia-integration.php
@@ -8,7 +8,7 @@
  * License: GPL2
  * Text Domain: newspack-tecnavia-integration
  *
- * @package Newspack_Tecnavia_Integration
+ * @package Newspack\TecnaviaIntegration
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -26,3 +26,5 @@ if ( ! defined( 'NEWSPACK_TECNAVIA_INTEGRATION_PLUGIN_DIR' ) ) {
 }
 
 require_once 'vendor/autoload.php';
+
+Newspack\TecnaviaIntegration\Initializer::init();


### PR DESCRIPTION
### Changes
Add two new classes to streamline dependency management and plugin initialization
- DependencyChecker Class: Provides methods to verify the installation and activation status of required plugins:
  - WooCommerce
  - WooCommerce Memberships
  - WooCommerce Subscriptions

- Initializer: Handles plugin initialization by setting up hooks and filters. Validates dependencies during initialization using the DependencyChecker class. Displays admin notices to alert users of missing or inactive dependencies

### Testing

1.  Install and activate the following plugins:
    - WooCommerce
    - WooCommerce Memberships
    - WooCommerce Subscriptions

2. Deactivate any of the above plugins to test missing dependency scenarios.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209191663252031