### PR TITLE
feat(settings): Add settings for necessary fields

### DIFF
--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -18,6 +18,11 @@ class Initializer {
 	public static function init() {
 		// Setup Hooks & Filters.
 		add_action( 'admin_notices', array( __CLASS__, 'show_admin_notice__error' ) );
+
+		// Initialize classes only when all dependencies are met.
+		if ( self::has_valid_dependencies() ) {
+			Settings::init();
+		}
 	}
 
 	/**

--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -19,10 +19,7 @@ class Initializer {
 		// Setup Hooks & Filters.
 		add_action( 'admin_notices', array( __CLASS__, 'show_admin_notice__error' ) );
 
-		// Initialize classes only when all dependencies are met.
-		if ( self::has_valid_dependencies() ) {
-			Settings::init();
-		}
+		Settings::init();
 	}
 
 	/**

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -23,6 +23,15 @@ class Settings {
 	const E_EDITION_ENDPOINT_LINK_LABEL  = 'np_wc_tecnavia_e_edition_endpoint_link_label';
 	const TECNAVIA_URL_OPTION            = 'np_wc_tecnavia_url';
 	const FALLBACK_PAGE_ID_OPTION        = 'np_wc_tecnavia_fallback_page_id';
+	const TECNAVIA_PERMISSIONS_OPTION    = 'np_wc_tecnavia_permissions';
+
+	/**
+	 * Access settings constants.
+	 */
+	const NP_TECNAVIA_ACCESS_SETTING_ALL_REGISTERED_USERS_KEY  = 'all_registered_users';
+	const NP_TECNAVIA_ACCESS_SETTING_ALLOWED_ROLES_KEY         = 'allowed_roles';
+	const NP_TECNAVIA_ACCESS_SETTING_ALLOWED_SUBSCRIPTIONS_KEY = 'allowed_subscription_products';
+	const NP_TECNAVIA_ACCESS_SETTING_ALLOWED_MEMBERSHIPS_KEY   = 'allowed_memberships';
 
 	/**
 	 * Runs the initialization.
@@ -49,7 +58,12 @@ class Settings {
 			self::E_EDITION_ENDPOINT_URL_OPTION,
 			self::TECNAVIA_URL_OPTION,
 			self::E_EDITION_ENDPOINT_LINK_LABEL,
-			self::FALLBACK_PAGE_ID_OPTION
+			self::FALLBACK_PAGE_ID_OPTION,
+			self::TECNAVIA_PERMISSIONS_OPTION,
+			self::NP_TECNAVIA_ACCESS_SETTING_ALL_REGISTERED_USERS_KEY,
+			self::NP_TECNAVIA_ACCESS_SETTING_ALLOWED_ROLES_KEY,
+			self::NP_TECNAVIA_ACCESS_SETTING_ALLOWED_SUBSCRIPTIONS_KEY,
+			self::NP_TECNAVIA_ACCESS_SETTING_ALLOWED_MEMBERSHIPS_KEY
 		);
 
 		// Return the settings.
@@ -143,5 +157,14 @@ class Settings {
 	 */
 	public static function get_fallback_page_id() {
 		return get_option( self::FALLBACK_PAGE_ID_OPTION );
+	}
+
+	/**
+	 * Get the Tecnavia permissions.
+	 *
+	 * @return array
+	 */
+	public static function get_tecnavia_access_permissions() {
+		return get_option( self::TECNAVIA_PERMISSIONS_OPTION );
 	}
 }

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Settings Menu
+ *
+ * @package Newspack\TecnaviaIntegration
+ */
+
+namespace Newspack\TecnaviaIntegration;
+
+use Newspack\TecnaviaIntegration\WooCommerce\Settings\WC_Settings_Option_Tab;
+
+/**
+ * Add Settings to configure the integration.
+ *
+ * @since 1.0
+ */
+class Settings {
+
+	const E_EDITION_ENDPOINT_URL_OPTION = 'np_wc_tecnavia_e_edition_endpoint_url';
+	const TECNAVIA_URL_OPTION           = 'np_wc_tecnavia_url';
+
+	/**
+	 * Runs the initialization.
+	 */
+	public static function init() {
+		// Setup Hooks & Filters.
+		add_filter( 'woocommerce_get_settings_pages', array( __CLASS__, 'add_wc_settings_page' ) );
+		add_filter( 'woocommerce_account_menu_items', array( __CLASS__, 'add_wc_account_menu_item' ), 20, 1 );
+		add_filter( 'woocommerce_get_endpoint_url', array( __CLASS__, 'add_wc_endpoint_url' ), 10, 4 );
+	}
+
+	/**
+	 * Add the Newspack-Tecnavia settings page to WooCommerce settings.
+	 *
+	 * @param array $settings Array of WooCommerce settings pages.
+	 * @return array
+	 */
+	public static function add_wc_settings_page( $settings ) {
+		$settings[] = include_once __DIR__ . '/woocommerce/class-wc-settings-option-tab.php';
+		new WC_Settings_Option_Tab( self::E_EDITION_ENDPOINT_URL_OPTION, self::TECNAVIA_URL_OPTION );
+		return $settings;
+	}
+
+	/**
+	 * Add the Newspack-Tecnavia account menu item to WooCommerce account menu.
+	 *
+	 * @param array $items Array of WooCommerce account menu items.
+	 * @return array
+	 */
+	public static function add_wc_account_menu_item( $items ) {
+		// Create the e-edition link.
+		$e_edition_link = array(
+			'e-edition' => __( 'E-Edition', 'newspack-tecnavia-integration' ),
+		);
+
+		// Add the e-edition link to the account menu at the second last position.
+		$items = array_slice( $items, 0, -1, true ) + $e_edition_link + array_slice( $items, -1, null, true );
+
+		return $items;
+	}
+
+	/**
+	 * Override the e-edition endpoint URL.
+	 *
+	 * @param string $url URL of the endpoint.
+	 * @param string $endpoint Endpoint name.
+	 * @param int    $value Value of the endpoint.
+	 * @param string $permalink Permalink of the endpoint.
+	 * @return string
+	 */
+	public static function add_wc_endpoint_url( $url, $endpoint, $value, $permalink ) {
+		// Check if the endpoint is the e-edition.
+		if ( $endpoint !== 'e-edition' ) {
+			return $url;
+		}
+
+		// Get the Tecnavia URL.
+		$technavia_url = get_option( self::TECNAVIA_URL_OPTION );
+
+		// Bail if the Tecnavia URL is not set.
+		if ( empty( $technavia_url ) ) {
+			return $url;
+		}
+
+		// Return the Tecnavia URL.
+		return $technavia_url;
+	}
+}

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -16,9 +16,13 @@ use Newspack\TecnaviaIntegration\WooCommerce\Settings\WC_Settings_Option_Tab;
  */
 class Settings {
 
+	/**
+	 * Option names.
+	 */
 	const E_EDITION_ENDPOINT_URL_OPTION  = 'np_wc_tecnavia_e_edition_endpoint_url';
 	const E_EDITION_ENDPOINT_LINK_LABEL  = 'np_wc_tecnavia_e_edition_endpoint_link_label';
 	const TECNAVIA_URL_OPTION            = 'np_wc_tecnavia_url';
+	const FALLBACK_PAGE_ID_OPTION        = 'np_wc_tecnavia_fallback_page_id';
 
 	/**
 	 * Runs the initialization.
@@ -37,8 +41,18 @@ class Settings {
 	 * @return array
 	 */
 	public static function add_wc_settings_page( $settings ) {
+		// Add the Newspack-Tecnavia settings page.
 		$settings[] = include_once __DIR__ . '/woocommerce/class-wc-settings-option-tab.php';
-		new WC_Settings_Option_Tab( self::E_EDITION_ENDPOINT_URL_OPTION, self::TECNAVIA_URL_OPTION, self::E_EDITION_ENDPOINT_LINK_LABEL );
+
+		// Initialize the settings page.
+		new WC_Settings_Option_Tab(
+			self::E_EDITION_ENDPOINT_URL_OPTION,
+			self::TECNAVIA_URL_OPTION,
+			self::E_EDITION_ENDPOINT_LINK_LABEL,
+			self::FALLBACK_PAGE_ID_OPTION
+		);
+
+		// Return the settings.
 		return $settings;
 	}
 

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -16,8 +16,9 @@ use Newspack\TecnaviaIntegration\WooCommerce\Settings\WC_Settings_Option_Tab;
  */
 class Settings {
 
-	const E_EDITION_ENDPOINT_URL_OPTION = 'np_wc_tecnavia_e_edition_endpoint_url';
-	const TECNAVIA_URL_OPTION           = 'np_wc_tecnavia_url';
+	const E_EDITION_ENDPOINT_URL_OPTION  = 'np_wc_tecnavia_e_edition_endpoint_url';
+	const E_EDITION_ENDPOINT_LINK_LABEL  = 'np_wc_tecnavia_e_edition_endpoint_link_label';
+	const TECNAVIA_URL_OPTION            = 'np_wc_tecnavia_url';
 
 	/**
 	 * Runs the initialization.
@@ -37,7 +38,7 @@ class Settings {
 	 */
 	public static function add_wc_settings_page( $settings ) {
 		$settings[] = include_once __DIR__ . '/woocommerce/class-wc-settings-option-tab.php';
-		new WC_Settings_Option_Tab( self::E_EDITION_ENDPOINT_URL_OPTION, self::TECNAVIA_URL_OPTION );
+		new WC_Settings_Option_Tab( self::E_EDITION_ENDPOINT_URL_OPTION, self::TECNAVIA_URL_OPTION, self::E_EDITION_ENDPOINT_LINK_LABEL );
 		return $settings;
 	}
 
@@ -50,7 +51,7 @@ class Settings {
 	public static function add_wc_account_menu_item( $items ) {
 		// Create the e-edition link.
 		$e_edition_link = array(
-			'e-edition' => __( 'E-Edition', 'newspack-tecnavia-integration' ),
+			'e-edition' => get_option( self::E_EDITION_ENDPOINT_LINK_LABEL ),
 		);
 
 		// Add the e-edition link to the account menu at the second last position.

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -28,10 +28,10 @@ class Settings {
 	/**
 	 * Access settings constants.
 	 */
-	const NP_TECNAVIA_ACCESS_SETTING_ALL_REGISTERED_USERS_KEY  = 'all_registered_users';
-	const NP_TECNAVIA_ACCESS_SETTING_ALLOWED_ROLES_KEY         = 'allowed_roles';
-	const NP_TECNAVIA_ACCESS_SETTING_ALLOWED_SUBSCRIPTIONS_KEY = 'allowed_subscription_products';
-	const NP_TECNAVIA_ACCESS_SETTING_ALLOWED_MEMBERSHIPS_KEY   = 'allowed_memberships';
+	const ALL_REGISTERED_USERS_ACCESS_KEY  = 'all_registered_users';
+	const ALLOWED_ROLES_ACCESS_KEY         = 'allowed_roles';
+	const ALLOWED_SUBSCRIPTIONS_ACCESS_KEY = 'allowed_subscription_products';
+	const ALLOWED_MEMBERSHIPS_ACCESS_KEY   = 'allowed_memberships';
 
 	/**
 	 * Runs the initialization.
@@ -59,11 +59,7 @@ class Settings {
 			self::TECNAVIA_URL_OPTION,
 			self::E_EDITION_ENDPOINT_LINK_LABEL,
 			self::FALLBACK_PAGE_ID_OPTION,
-			self::TECNAVIA_PERMISSIONS_OPTION,
-			self::NP_TECNAVIA_ACCESS_SETTING_ALL_REGISTERED_USERS_KEY,
-			self::NP_TECNAVIA_ACCESS_SETTING_ALLOWED_ROLES_KEY,
-			self::NP_TECNAVIA_ACCESS_SETTING_ALLOWED_SUBSCRIPTIONS_KEY,
-			self::NP_TECNAVIA_ACCESS_SETTING_ALLOWED_MEMBERSHIPS_KEY
+			self::TECNAVIA_PERMISSIONS_OPTION
 		);
 
 		// Return the settings.

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -40,7 +40,7 @@ class Settings {
 	 * @param array $settings Array of WooCommerce settings pages.
 	 * @return array
 	 */
-	public function add_wc_settings_page( $settings ) {
+	public static function add_wc_settings_page( $settings ) {
 		// Add the Newspack-Tecnavia settings page.
 		$settings[] = include_once __DIR__ . '/woocommerce/class-wc-settings-option-tab.php';
 
@@ -62,7 +62,7 @@ class Settings {
 	 * @param array $items Array of WooCommerce account menu items.
 	 * @return array
 	 */
-	public function add_wc_account_menu_item( $items ) {
+	public static function add_wc_account_menu_item( $items ) {
 		// Create the e-edition link.
 		$e_edition_link = array(
 			'e-edition' => get_option( self::E_EDITION_ENDPOINT_LINK_LABEL ),
@@ -83,7 +83,7 @@ class Settings {
 	 * @param string $permalink Permalink of the endpoint.
 	 * @return string
 	 */
-	public function add_wc_endpoint_url( $url, $endpoint, $value, $permalink ) {
+	public static function add_wc_endpoint_url( $url, $endpoint, $value, $permalink ) {
 		// Check if the endpoint is the e-edition.
 		if ( $endpoint !== 'e-edition' ) {
 			return $url;

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -40,7 +40,7 @@ class Settings {
 	 * @param array $settings Array of WooCommerce settings pages.
 	 * @return array
 	 */
-	public static function add_wc_settings_page( $settings ) {
+	public function add_wc_settings_page( $settings ) {
 		// Add the Newspack-Tecnavia settings page.
 		$settings[] = include_once __DIR__ . '/woocommerce/class-wc-settings-option-tab.php';
 
@@ -62,7 +62,7 @@ class Settings {
 	 * @param array $items Array of WooCommerce account menu items.
 	 * @return array
 	 */
-	public static function add_wc_account_menu_item( $items ) {
+	public function add_wc_account_menu_item( $items ) {
 		// Create the e-edition link.
 		$e_edition_link = array(
 			'e-edition' => get_option( self::E_EDITION_ENDPOINT_LINK_LABEL ),
@@ -83,14 +83,14 @@ class Settings {
 	 * @param string $permalink Permalink of the endpoint.
 	 * @return string
 	 */
-	public static function add_wc_endpoint_url( $url, $endpoint, $value, $permalink ) {
+	public function add_wc_endpoint_url( $url, $endpoint, $value, $permalink ) {
 		// Check if the endpoint is the e-edition.
 		if ( $endpoint !== 'e-edition' ) {
 			return $url;
 		}
 
 		// Get the Tecnavia URL.
-		$technavia_url = get_option( self::TECNAVIA_URL_OPTION );
+		$technavia_url = site_url( get_option( self::E_EDITION_ENDPOINT_URL_OPTION ) );
 
 		// Bail if the Tecnavia URL is not set.
 		if ( empty( $technavia_url ) ) {

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -65,7 +65,7 @@ class Settings {
 	public static function add_wc_account_menu_item( $items ) {
 		// Create the e-edition link.
 		$e_edition_link = array(
-			'e-edition' => get_option( self::E_EDITION_ENDPOINT_LINK_LABEL ),
+			'e-edition' => self::get_e_edition_endpoint_link_label(),
 		);
 
 		// Add the e-edition link to the account menu at the second last position.
@@ -89,15 +89,59 @@ class Settings {
 			return $url;
 		}
 
-		// Get the Tecnavia URL.
-		$technavia_url = site_url( get_option( self::E_EDITION_ENDPOINT_URL_OPTION ) );
+		// Get the e-edition URL.
+		$e_edition_url = self::get_e_edition_endpoint_url();
 
-		// Bail if the Tecnavia URL is not set.
-		if ( empty( $technavia_url ) ) {
+		// Bail if the e-edition URL is empty.
+		if ( empty( $e_edition_url ) ) {
 			return $url;
 		}
 
-		// Return the Tecnavia URL.
-		return $technavia_url;
+		return $e_edition_url;
+	}
+
+	/**
+	 * Get the e-edition endpoint URL.
+	 *
+	 * @return string
+	 */
+	public static function get_e_edition_url_endpoint() {
+		return get_option( self::E_EDITION_ENDPOINT_URL_OPTION );
+	}
+
+	/**
+	 * Get the e-edition endpoint URL.
+	 *
+	 * @return string
+	 */
+	public static function get_e_edition_endpoint_url() {
+		return site_url( self::get_e_edition_url_endpoint() );
+	}
+
+	/**
+	 * Get the e-edition endpoint link label.
+	 *
+	 * @return string
+	 */
+	public static function get_e_edition_endpoint_link_label() {
+		return get_option( self::E_EDITION_ENDPOINT_LINK_LABEL );
+	}
+
+	/**
+	 * Get the Tecnavia URL.
+	 *
+	 * @return string
+	 */
+	public static function get_tecnavia_url() {
+		return esc_url_raw( get_option( self::TECNAVIA_URL_OPTION ) );
+	}
+
+	/**
+	 * Get the fallback page ID.
+	 *
+	 * @return int
+	 */
+	public static function get_fallback_page_id() {
+		return get_option( self::FALLBACK_PAGE_ID_OPTION );
 	}
 }

--- a/includes/woocommerce/class-wc-settings-option-tab.php
+++ b/includes/woocommerce/class-wc-settings-option-tab.php
@@ -39,19 +39,33 @@ class WC_Settings_Option_Tab extends WC_Settings_Page {
 	private $technavia_url_option;
 
 	/**
+	 * Newspack Tecnavia Integration fallback page ID.
+	 *
+	 * @var string
+	 */
+	private $fallback_page_id_option;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $e_edition_endpoint_url_option e-edition endpoint URL option name.
 	 * @param string $technavia_url_option Tecnavia URL option name.
 	 * @param string $e_edition_endpoint_link_label e-edition endpoint link label option name.
+	 * @param string $fallback_page_id_option Fallback page ID option name.
 	 */
-	public function __construct( $e_edition_endpoint_url_option, $technavia_url_option, $e_edition_endpoint_link_label ) {
+	public function __construct(
+		$e_edition_endpoint_url_option,
+		$technavia_url_option,
+		$e_edition_endpoint_link_label,
+		$fallback_page_id_option
+	) {
 		/**
 		 * Initialize constants.
 		 */
 		$this->e_edition_endpoint_url_option = $e_edition_endpoint_url_option;
 		$this->e_edition_endpoint_link_label = $e_edition_endpoint_link_label;
 		$this->technavia_url_option          = $technavia_url_option;
+		$this->fallback_page_id_option       = $fallback_page_id_option;
 
 		/**
 		 * Define the tab name and label
@@ -113,6 +127,13 @@ class WC_Settings_Option_Tab extends WC_Settings_Page {
 				'desc_tip' => true,
 				'id'       => $this->technavia_url_option,
 				'css'      => 'min-width:600px;',
+			),
+			array(
+				'title'    => __( 'Fallback Page', 'newspack-tecnavia-integration' ),
+				'type'     => 'single_select_page',
+				'desc'     => __( 'Select the fallback page.', 'newspack-tecnavia-integration' ),
+				'desc_tip' => true,
+				'id'       => $this->fallback_page_id_option,
 			),
 			array(
 				'type' => 'sectionend',

--- a/includes/woocommerce/class-wc-settings-option-tab.php
+++ b/includes/woocommerce/class-wc-settings-option-tab.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Settings Menu
+ *
+ * @package Newspack\TecnaviaIntegration
+ */
+
+namespace Newspack\TecnaviaIntegration\WooCommerce\Settings;
+
+use WC_Admin_Settings;
+use WC_Settings_Page;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the setting required to integrate the plugin's option tab into WooCommerce 'Settings' page.
+ */
+class WC_Settings_Option_Tab extends WC_Settings_Page {
+
+	/**
+	 * Newspack Tecnavia Integration e-edition endpoint URL.
+	 *
+	 * @var string
+	 */
+	private $e_edition_endpoint_url_option;
+
+	/**
+	 * Newspack Tecnavia Integration Tecnavia URL.
+	 *
+	 * @var string
+	 */
+	private $technavia_url_option;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $e_edition_endpoint_url_option e-edition endpoint URL option name.
+	 * @param string $technavia_url_option Tecnavia URL option name.
+	 */
+	public function __construct( $e_edition_endpoint_url_option, $technavia_url_option ) {
+		/**
+		 * Initialize constants.
+		 */
+		$this->e_edition_endpoint_url_option = $e_edition_endpoint_url_option;
+		$this->technavia_url_option          = $technavia_url_option;
+
+		/**
+		 * Define the tab name and label
+		 */
+		$this->id    = 'newspack-tecnavia-integration-settings';
+		$this->label = __( 'Newspack Tecnavia Integration', 'newspack-tecnavia-integration' );
+
+		/**
+		 * Define all hooks instead of inheriting from parent
+		 */
+		// Add the tab to the tabs array.
+		add_filter( 'woocommerce_settings_tabs_array', array( $this, 'add_settings_page' ), 60 );
+
+		// Add settings.
+		add_action( 'woocommerce_settings_' . $this->id, array( $this, 'render_page' ) );
+
+		// Process/save the settings.
+		add_action( 'woocommerce_settings_save_' . $this->id, array( $this, 'save_settings' ) );
+	}
+
+
+	/**
+	 * Get settings array
+	 *
+	 * @return array
+	 */
+	public function get_settings() {
+		/**
+		 * Settings for the Tecnavia Integration
+		 */
+		$settings = array(
+			// License input.
+			array(
+				'title' => __( 'Tecnavia Settings', 'newspack-tecnavia-integration' ),
+				'type'  => 'title',
+				'desc'  => __( 'Settings for the Tecnavia Integration', 'newspack-tecnavia-integration' ),
+				'id'    => 'np_wc_tecnavia_settings',
+			),
+			array(
+				'title'    => __( 'E-edition Endpoint URL', 'newspack-tecnavia-integration' ),
+				'type'     => 'text',
+				'desc'     => __( 'Add the URL of the e-edition endpoint.', 'newspack-tecnavia-integration' ),
+				'desc_tip' => true,
+				'id'       => $this->e_edition_endpoint_url_option,
+				'css'      => 'min-width:600px;',
+			),
+			array(
+				'title'    => __( 'Tecnavia URL', 'newspack-tecnavia-integration' ),
+				'type'     => 'text',
+				'desc'     => __( 'Add the URL of the Tecnavia service.', 'newspack-tecnavia-integration' ),
+				'desc_tip' => true,
+				'id'       => $this->technavia_url_option,
+				'css'      => 'min-width:600px;',
+			),
+			array(
+				'type' => 'sectionend',
+				'id'   => 'np_wc_tecnavia_settings',
+			),
+		);
+
+		return apply_filters( 'woocommerce_get_settings_' . $this->id, $settings );
+	}
+
+	/**
+	 * Output the settings
+	 */
+	public function render_page() {
+		// Fetch the settings.
+		$settings = $this->get_settings();
+
+		// Render the settings.
+		WC_Admin_Settings::output_fields( $settings );
+	}
+
+	/**
+	 * Save the settings
+	 */
+	public function save_settings() {
+		// Fetch the settings.
+		$settings = $this->get_settings();
+
+		// Save the settings.
+		WC_Admin_Settings::save_fields( $settings );
+
+		// Trigger an action hook.
+		do_action( 'woocommerce_update_options_' . $this->id );
+	}
+}

--- a/includes/woocommerce/class-wc-settings-option-tab.php
+++ b/includes/woocommerce/class-wc-settings-option-tab.php
@@ -7,6 +7,7 @@
 
 namespace Newspack\TecnaviaIntegration\WooCommerce\Settings;
 
+use Newspack\TecnaviaIntegration\Settings;
 use WC_Admin_Settings;
 use WC_Settings_Page;
 
@@ -18,7 +19,7 @@ defined( 'ABSPATH' ) || exit;
 class WC_Settings_Option_Tab extends WC_Settings_Page {
 
 	/**
-	 * Newspack Tecnavia Integration e-edition endpoint URL.
+	 * Newspack Tecnavia Integration e-edition URL endpoint.
 	 *
 	 * @var string
 	 */
@@ -53,46 +54,18 @@ class WC_Settings_Option_Tab extends WC_Settings_Page {
 	private $tecnavia_permissions_option;
 
 	/**
-	 * All registered users.
-	 *
-	 * @var string
-	 */
-	private $np_tecnavia_access_setting_all_registered_users_key;
-
-	/**
-	 * Allowed roles.
-	 *
-	 * @var string
-	 */
-	private $np_tecnavia_access_setting_allowed_roles_key;
-
-	/**
-	 * Allowed subscriptions.
-	 *
-	 * @var string
-	 */
-	private $np_tecnavia_access_setting_allowed_subscriptions_key;
-
-	/**
-	 * Allowed memberships.
-	 *
-	 * @var string
-	 */
-	private $np_tecnavia_access_setting_allowed_memberships_key;
-
-	/**
 	 * Version of the Tecnavia assets.
 	 *
 	 * @var string
 	 */
-	const NEWSPACK_TECNAVIA_ASSETS_VERSION = '1.0';
+	const ASSETS_VERSION = '1.0';
 
 	/**
 	 * Tab ID.
 	 *
 	 * @var string
 	 */
-	const NEWSPACK_TECNAVIA_SETTINGS_TAB = 'newspack-tecnavia-integration-settings';
+	const NP_TECNAVIA_SETTINGS_TAB = 'newspack-tecnavia-integration-settings';
 
 	/**
 	 * Constructor.
@@ -102,10 +75,6 @@ class WC_Settings_Option_Tab extends WC_Settings_Page {
 	 * @param string $e_edition_endpoint_link_label Newspack Tecnavia Integration e-edition endpoint link label.
 	 * @param string $fallback_page_id_option Newspack Tecnavia Integration fallback page ID.
 	 * @param string $tecnavia_permissions_option Newspack Tecnavia Integration permissions.
-	 * @param string $np_tecnavia_access_setting_all_registered_users_key All registered users.
-	 * @param string $np_tecnavia_access_setting_allowed_roles_key Allowed roles.
-	 * @param string $np_tecnavia_access_setting_allowed_subscriptions_key Allowed subscriptions.
-	 * @param string $np_tecnavia_access_setting_allowed_memberships_key Allowed memberships.
 	 */
 	public function __construct(
 		$e_edition_endpoint_url_option,
@@ -113,10 +82,6 @@ class WC_Settings_Option_Tab extends WC_Settings_Page {
 		$e_edition_endpoint_link_label,
 		$fallback_page_id_option,
 		$tecnavia_permissions_option,
-		$np_tecnavia_access_setting_all_registered_users_key,
-		$np_tecnavia_access_setting_allowed_roles_key,
-		$np_tecnavia_access_setting_allowed_subscriptions_key,
-		$np_tecnavia_access_setting_allowed_memberships_key
 	) {
 		/**
 		 * Initialize constants.
@@ -128,17 +93,9 @@ class WC_Settings_Option_Tab extends WC_Settings_Page {
 		$this->tecnavia_permissions_option   = $tecnavia_permissions_option;
 
 		/**
-		 * Initialize access settings constants.
-		 */
-		$this->np_tecnavia_access_setting_all_registered_users_key = $np_tecnavia_access_setting_all_registered_users_key;
-		$this->np_tecnavia_access_setting_allowed_roles_key        = $np_tecnavia_access_setting_allowed_roles_key;
-		$this->np_tecnavia_access_setting_allowed_subscriptions_key = $np_tecnavia_access_setting_allowed_subscriptions_key;
-		$this->np_tecnavia_access_setting_allowed_memberships_key   = $np_tecnavia_access_setting_allowed_memberships_key;
-
-		/**
 		 * Define the tab name and label
 		 */
-		$this->id    = self::NEWSPACK_TECNAVIA_SETTINGS_TAB;
+		$this->id    = self::NP_TECNAVIA_SETTINGS_TAB;
 		$this->label = __( 'Newspack Tecnavia Integration', 'newspack-tecnavia-integration' );
 
 		/**
@@ -164,13 +121,14 @@ class WC_Settings_Option_Tab extends WC_Settings_Page {
 	 */
 	public function get_settings() {
 		/**
-		 * Define the settings keys.
-		 * Store the access settings as an array under a single option ( $tecnavia_permissions_option ).
+		 * Construct the access settings ids.
+		 * Ids are constructed to be used as array keys in the permissions option.
+		 * It will store the access settings as an array under a single option ( $tecnavia_permissions_option ).
 		 */
-		$all_registered_users  = '[' . $this->np_tecnavia_access_setting_all_registered_users_key . ']';
-		$allowed_roles         = '[' . $this->np_tecnavia_access_setting_allowed_roles_key . ']';
-		$allowed_subscriptions = '[' . $this->np_tecnavia_access_setting_allowed_subscriptions_key . ']';
-		$allowed_memberships   = '[' . $this->np_tecnavia_access_setting_allowed_memberships_key . ']';
+		$all_registered_users_id  = $this->tecnavia_permissions_option . '[' . Settings::ALL_REGISTERED_USERS_ACCESS_KEY . ']';
+		$allowed_roles_id         = $this->tecnavia_permissions_option . '[' . Settings::ALLOWED_ROLES_ACCESS_KEY . ']';
+		$allowed_subscription_id  = $this->tecnavia_permissions_option . '[' . Settings::ALLOWED_SUBSCRIPTIONS_ACCESS_KEY . ']';
+		$allowed_memberships_id   = $this->tecnavia_permissions_option . '[' . Settings::ALLOWED_MEMBERSHIPS_ACCESS_KEY . ']';
 
 		/**
 		 * Settings for the Tecnavia Integration
@@ -222,13 +180,13 @@ class WC_Settings_Option_Tab extends WC_Settings_Page {
 				'desc'  => __( 'Define the criteria for reader access to Tecnavia.', 'newspack-tecnavia-integration' ),
 				'id'    => 'np_wc_tecnavia_access_settings',
 			),
-			
+
 			// Checkbox: All registered users have access.
 			array(
 				'title'             => __( 'Allow all Registered Users', 'newspack-tecnavia-integration' ),
 				'type'              => 'checkbox',
 				'desc'              => __( 'Grant access to all registered users. NOTE: This will overrule other settings.', 'newspack-tecnavia-integration' ),
-				'id'                => $this->tecnavia_permissions_option . $all_registered_users,
+				'id'                => $all_registered_users_id,
 				'custom_attributes' => array(
 					'data-dependency' => true,
 				),
@@ -240,12 +198,12 @@ class WC_Settings_Option_Tab extends WC_Settings_Page {
 			'title'             => __( 'Allowed Roles', 'newspack-tecnavia-integration' ),
 			'type'              => 'multiselect',
 			'desc'              => __( 'Select roles that have access.', 'newspack-tecnavia-integration' ),
-			'id'                => $this->tecnavia_permissions_option . $allowed_roles,
+			'id'                => $allowed_roles_id,
 			'class'             => 'wc-enhanced-select',
 			'options'           => $this->get_roles_options(),
 			'css'               => 'min-width:600px;',
 			'custom_attributes' => array(
-				'data-dependent-on' => $this->tecnavia_permissions_option . $all_registered_users,
+				'data-dependent-on' => $all_registered_users_id,
 			),
 		);
 
@@ -255,12 +213,12 @@ class WC_Settings_Option_Tab extends WC_Settings_Page {
 				'title'             => __( 'By Woo Subscription', 'newspack-tecnavia-integration' ),
 				'type'              => 'multiselect',
 				'desc'              => __( 'Select WooCommerce Subscriptions that grant access.', 'newspack-tecnavia-integration' ),
-				'id'                => $this->tecnavia_permissions_option . $allowed_subscriptions,
+				'id'                => $allowed_subscription_id,
 				'class'             => 'wc-enhanced-select',
 				'options'           => $this->get_woocommerce_subscription_products_options(),
 				'css'               => 'min-width:600px;',
 				'custom_attributes' => array(
-					'data-dependent-on' => $this->tecnavia_permissions_option . $all_registered_users,
+					'data-dependent-on' => $all_registered_users_id,
 				),
 			);
 		}
@@ -271,12 +229,12 @@ class WC_Settings_Option_Tab extends WC_Settings_Page {
 				'title'             => __( 'By Woo Membership', 'newspack-tecnavia-integration' ),
 				'type'              => 'multiselect',
 				'desc'              => __( 'Select WooCommerce Memberships that grant access.', 'newspack-tecnavia-integration' ),
-				'id'                => $this->tecnavia_permissions_option . $allowed_memberships,
+				'id'                => $allowed_memberships_id,
 				'class'             => 'wc-enhanced-select',
 				'options'           => $this->get_woocommerce_memberships_options(),
 				'css'               => 'min-width:600px;',
 				'custom_attributes' => array(
-					'data-dependent-on' => $this->tecnavia_permissions_option . $all_registered_users,
+					'data-dependent-on' => $all_registered_users_id,
 				),
 			);
 		}
@@ -287,7 +245,7 @@ class WC_Settings_Option_Tab extends WC_Settings_Page {
 			'id'   => 'np_wc_tecnavia_access_settings',
 		);
 
-		return apply_filters( 'woocommerce_get_settings_' . $this->id, $settings );
+		return $settings;
 	}
 
 	/**
@@ -310,9 +268,6 @@ class WC_Settings_Option_Tab extends WC_Settings_Page {
 
 		// Save the settings.
 		WC_Admin_Settings::save_fields( $settings );
-
-		// Trigger an action hook.
-		do_action( 'woocommerce_update_options_' . $this->id );
 	}
 
 	/**
@@ -403,13 +358,13 @@ class WC_Settings_Option_Tab extends WC_Settings_Page {
 		if (
 			'woocommerce_page_wc-settings' === $hook &&
 			! empty( $current_tab )
-			&& self::NEWSPACK_TECNAVIA_SETTINGS_TAB === $current_tab
+			&& self::NP_TECNAVIA_SETTINGS_TAB === $current_tab
 		) {
 			wp_enqueue_script(
 				'newspack-tecnavia-integration-admin',
 				$src_dir,
 				[],
-				self::NEWSPACK_TECNAVIA_ASSETS_VERSION,
+				self::ASSETS_VERSION,
 				true
 			);
 		}

--- a/includes/woocommerce/class-wc-settings-option-tab.php
+++ b/includes/woocommerce/class-wc-settings-option-tab.php
@@ -46,18 +46,77 @@ class WC_Settings_Option_Tab extends WC_Settings_Page {
 	private $fallback_page_id_option;
 
 	/**
+	 * Newspack Tecnavia Integration permissions.
+	 *
+	 * @var array
+	 */
+	private $tecnavia_permissions_option;
+
+	/**
+	 * All registered users.
+	 *
+	 * @var string
+	 */
+	private $np_tecnavia_access_setting_all_registered_users_key;
+
+	/**
+	 * Allowed roles.
+	 *
+	 * @var string
+	 */
+	private $np_tecnavia_access_setting_allowed_roles_key;
+
+	/**
+	 * Allowed subscriptions.
+	 *
+	 * @var string
+	 */
+	private $np_tecnavia_access_setting_allowed_subscriptions_key;
+
+	/**
+	 * Allowed memberships.
+	 *
+	 * @var string
+	 */
+	private $np_tecnavia_access_setting_allowed_memberships_key;
+
+	/**
+	 * Version of the Tecnavia assets.
+	 *
+	 * @var string
+	 */
+	const NEWSPACK_TECNAVIA_ASSETS_VERSION = '1.0';
+
+	/**
+	 * Tab ID.
+	 *
+	 * @var string
+	 */
+	const NEWSPACK_TECNAVIA_SETTINGS_TAB = 'newspack-tecnavia-integration-settings';
+
+	/**
 	 * Constructor.
 	 *
-	 * @param string $e_edition_endpoint_url_option e-edition endpoint URL option name.
-	 * @param string $technavia_url_option Tecnavia URL option name.
-	 * @param string $e_edition_endpoint_link_label e-edition endpoint link label option name.
-	 * @param string $fallback_page_id_option Fallback page ID option name.
+	 * @param string $e_edition_endpoint_url_option Newspack Tecnavia Integration e-edition endpoint URL.
+	 * @param string $technavia_url_option Newspack Tecnavia Integration Tecnavia URL.
+	 * @param string $e_edition_endpoint_link_label Newspack Tecnavia Integration e-edition endpoint link label.
+	 * @param string $fallback_page_id_option Newspack Tecnavia Integration fallback page ID.
+	 * @param string $tecnavia_permissions_option Newspack Tecnavia Integration permissions.
+	 * @param string $np_tecnavia_access_setting_all_registered_users_key All registered users.
+	 * @param string $np_tecnavia_access_setting_allowed_roles_key Allowed roles.
+	 * @param string $np_tecnavia_access_setting_allowed_subscriptions_key Allowed subscriptions.
+	 * @param string $np_tecnavia_access_setting_allowed_memberships_key Allowed memberships.
 	 */
 	public function __construct(
 		$e_edition_endpoint_url_option,
 		$technavia_url_option,
 		$e_edition_endpoint_link_label,
-		$fallback_page_id_option
+		$fallback_page_id_option,
+		$tecnavia_permissions_option,
+		$np_tecnavia_access_setting_all_registered_users_key,
+		$np_tecnavia_access_setting_allowed_roles_key,
+		$np_tecnavia_access_setting_allowed_subscriptions_key,
+		$np_tecnavia_access_setting_allowed_memberships_key
 	) {
 		/**
 		 * Initialize constants.
@@ -66,11 +125,20 @@ class WC_Settings_Option_Tab extends WC_Settings_Page {
 		$this->e_edition_endpoint_link_label = $e_edition_endpoint_link_label;
 		$this->technavia_url_option          = $technavia_url_option;
 		$this->fallback_page_id_option       = $fallback_page_id_option;
+		$this->tecnavia_permissions_option   = $tecnavia_permissions_option;
+
+		/**
+		 * Initialize access settings constants.
+		 */
+		$this->np_tecnavia_access_setting_all_registered_users_key = $np_tecnavia_access_setting_all_registered_users_key;
+		$this->np_tecnavia_access_setting_allowed_roles_key        = $np_tecnavia_access_setting_allowed_roles_key;
+		$this->np_tecnavia_access_setting_allowed_subscriptions_key = $np_tecnavia_access_setting_allowed_subscriptions_key;
+		$this->np_tecnavia_access_setting_allowed_memberships_key   = $np_tecnavia_access_setting_allowed_memberships_key;
 
 		/**
 		 * Define the tab name and label
 		 */
-		$this->id    = 'newspack-tecnavia-integration-settings';
+		$this->id    = self::NEWSPACK_TECNAVIA_SETTINGS_TAB;
 		$this->label = __( 'Newspack Tecnavia Integration', 'newspack-tecnavia-integration' );
 
 		/**
@@ -84,8 +152,10 @@ class WC_Settings_Option_Tab extends WC_Settings_Page {
 
 		// Process/save the settings.
 		add_action( 'woocommerce_settings_save_' . $this->id, array( $this, 'save_settings' ) );
-	}
 
+		// Add custom javascript.
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_tab_scripts' ) );
+	}
 
 	/**
 	 * Get settings array
@@ -94,51 +164,127 @@ class WC_Settings_Option_Tab extends WC_Settings_Page {
 	 */
 	public function get_settings() {
 		/**
+		 * Define the settings keys.
+		 * Store the access settings as an array under a single option ( $tecnavia_permissions_option ).
+		 */
+		$all_registered_users  = '[' . $this->np_tecnavia_access_setting_all_registered_users_key . ']';
+		$allowed_roles         = '[' . $this->np_tecnavia_access_setting_allowed_roles_key . ']';
+		$allowed_subscriptions = '[' . $this->np_tecnavia_access_setting_allowed_subscriptions_key . ']';
+		$allowed_memberships   = '[' . $this->np_tecnavia_access_setting_allowed_memberships_key . ']';
+
+		/**
 		 * Settings for the Tecnavia Integration
 		 */
 		$settings = array(
 			// License input.
 			array(
-				'title' => __( 'Tecnavia Settings', 'newspack-tecnavia-integration' ),
+				'title' => __( 'Tecnavia Integration Settings', 'newspack-tecnavia-integration' ),
 				'type'  => 'title',
 				'desc'  => __( 'Settings for the Tecnavia Integration', 'newspack-tecnavia-integration' ),
 				'id'    => 'np_wc_tecnavia_settings',
 			),
 			array(
-				'title'    => __( 'E-edition Endpoint URL', 'newspack-tecnavia-integration' ),
-				'type'     => 'text',
-				'desc'     => __( 'Add the URL of the e-edition endpoint.', 'newspack-tecnavia-integration' ),
-				'desc_tip' => true,
-				'id'       => $this->e_edition_endpoint_url_option,
-				'css'      => 'min-width:600px;',
+				'title' => __( 'E-edition Endpoint URL', 'newspack-tecnavia-integration' ),
+				'type'  => 'text',
+				'desc'  => __( 'Add the endpoint for the URL of e-edition.', 'newspack-tecnavia-integration' ),
+				'id'    => $this->e_edition_endpoint_url_option,
+				'css'   => 'min-width:600px;',
 			),
 			array(
-				'title'    => __( 'E-edition Endpoint Link Label', 'newspack-tecnavia-integration' ),
-				'type'     => 'text',
-				'desc'     => __( 'Add the label for the e-edition endpoint link.', 'newspack-tecnavia-integration' ),
-				'desc_tip' => true,
-				'id'       => $this->e_edition_endpoint_link_label,
-				'css'      => 'min-width:300px;',
+				'title' => __( 'E-edition Endpoint Link Label', 'newspack-tecnavia-integration' ),
+				'type'  => 'text',
+				'desc'  => __( 'Add the label for the e-edition link.', 'newspack-tecnavia-integration' ),
+				'id'    => $this->e_edition_endpoint_link_label,
+				'css'   => 'min-width:300px;',
 			),
 			array(
-				'title'    => __( 'Tecnavia URL', 'newspack-tecnavia-integration' ),
-				'type'     => 'text',
-				'desc'     => __( 'Add the URL of the Tecnavia service.', 'newspack-tecnavia-integration' ),
-				'desc_tip' => true,
-				'id'       => $this->technavia_url_option,
-				'css'      => 'min-width:600px;',
+				'title' => __( 'Tecnavia URL', 'newspack-tecnavia-integration' ),
+				'type'  => 'text',
+				'desc'  => __( 'Add the URL of the Tecnavia service.', 'newspack-tecnavia-integration' ),
+				'id'    => $this->technavia_url_option,
+				'css'   => 'min-width:600px;',
 			),
 			array(
-				'title'    => __( 'Fallback Page', 'newspack-tecnavia-integration' ),
-				'type'     => 'single_select_page',
-				'desc'     => __( 'Select the fallback page.', 'newspack-tecnavia-integration' ),
-				'desc_tip' => true,
-				'id'       => $this->fallback_page_id_option,
+				'title' => __( 'Fallback Page', 'newspack-tecnavia-integration' ),
+				'type'  => 'single_select_page',
+				'desc'  => __( 'Select the fallback page in case the user does not have access.', 'newspack-tecnavia-integration' ),
+				'id'    => $this->fallback_page_id_option,
 			),
 			array(
 				'type' => 'sectionend',
 				'id'   => 'np_wc_tecnavia_settings',
 			),
+
+			// Settings for the access criteria.
+			array(
+				'title' => __( 'Access Criteria', 'newspack-tecnavia-integration' ),
+				'type'  => 'title',
+				'desc'  => __( 'Define the criteria for reader access to Tecnavia.', 'newspack-tecnavia-integration' ),
+				'id'    => 'np_wc_tecnavia_access_settings',
+			),
+			
+			// Checkbox: All registered users have access.
+			array(
+				'title'             => __( 'Allow all Registered Users', 'newspack-tecnavia-integration' ),
+				'type'              => 'checkbox',
+				'desc'              => __( 'Grant access to all registered users. NOTE: This will overrule other settings.', 'newspack-tecnavia-integration' ),
+				'id'                => $this->tecnavia_permissions_option . $all_registered_users,
+				'custom_attributes' => array(
+					'data-dependency' => true,
+				),
+			),
+		);
+
+		// Add roles settings.
+		$settings[] = array(
+			'title'             => __( 'Allowed Roles', 'newspack-tecnavia-integration' ),
+			'type'              => 'multiselect',
+			'desc'              => __( 'Select roles that have access.', 'newspack-tecnavia-integration' ),
+			'id'                => $this->tecnavia_permissions_option . $allowed_roles,
+			'class'             => 'wc-enhanced-select',
+			'options'           => $this->get_roles_options(),
+			'css'               => 'min-width:600px;',
+			'custom_attributes' => array(
+				'data-dependent-on' => $this->tecnavia_permissions_option . $all_registered_users,
+			),
+		);
+
+		// Add WooCommerce Subscriptions settings if the plugin is active.
+		if ( class_exists( 'WC_Subscriptions' ) ) {
+			$settings[] = array(
+				'title'             => __( 'By Woo Subscription', 'newspack-tecnavia-integration' ),
+				'type'              => 'multiselect',
+				'desc'              => __( 'Select WooCommerce Subscriptions that grant access.', 'newspack-tecnavia-integration' ),
+				'id'                => $this->tecnavia_permissions_option . $allowed_subscriptions,
+				'class'             => 'wc-enhanced-select',
+				'options'           => $this->get_woocommerce_subscription_products_options(),
+				'css'               => 'min-width:600px;',
+				'custom_attributes' => array(
+					'data-dependent-on' => $this->tecnavia_permissions_option . $all_registered_users,
+				),
+			);
+		}
+
+		// Add WooCommerce Memberships settings if the plugin is active.
+		if ( class_exists( 'WC_Memberships' ) ) {
+			$settings[] = array(
+				'title'             => __( 'By Woo Membership', 'newspack-tecnavia-integration' ),
+				'type'              => 'multiselect',
+				'desc'              => __( 'Select WooCommerce Memberships that grant access.', 'newspack-tecnavia-integration' ),
+				'id'                => $this->tecnavia_permissions_option . $allowed_memberships,
+				'class'             => 'wc-enhanced-select',
+				'options'           => $this->get_woocommerce_memberships_options(),
+				'css'               => 'min-width:600px;',
+				'custom_attributes' => array(
+					'data-dependent-on' => $this->tecnavia_permissions_option . $all_registered_users,
+				),
+			);
+		}
+
+		// Add the section end.
+		$settings[] = array(
+			'type' => 'sectionend',
+			'id'   => 'np_wc_tecnavia_access_settings',
 		);
 
 		return apply_filters( 'woocommerce_get_settings_' . $this->id, $settings );
@@ -167,5 +313,105 @@ class WC_Settings_Option_Tab extends WC_Settings_Page {
 
 		// Trigger an action hook.
 		do_action( 'woocommerce_update_options_' . $this->id );
+	}
+
+	/**
+	 * Helper function to fetch WordPress roles.
+	 *
+	 * @return array
+	 */
+	private function get_roles_options() {
+		// Fetch WordPress roles.
+		$roles = wp_roles()->roles;
+
+		// Prepare the options array.
+		$options = array();
+		foreach ( $roles as $key => $role ) {
+			$options[ $key ] = $role['name'];
+		}
+
+		return $options;
+	}
+
+	/**
+	 * Helper function to fetch WooCommerce Subscriptions.
+	 *
+	 * @return array
+	 */
+	private function get_woocommerce_subscription_products_options() {
+		// Check if WooCommerce Subscriptions is active.
+		if ( ! class_exists( 'WC_Subscriptions' ) ) {
+			return [];
+		}
+
+		// Fetch WooCommerce Subscriptions products.
+		$subscriptions = wc_get_products(
+			array(
+				array(
+					'variable-subscription', 
+					'subscription',
+				),
+				'limit' => -1,
+			)
+		);
+
+		// Prepare the options array.
+		$options = [];
+		foreach ( $subscriptions as $subscription ) {
+			$options[ $subscription->get_id() ] = $subscription->get_name();
+		}
+
+		return $options;
+	}
+
+	/**
+	 * Helper function to fetch WooCommerce Membership Plans.
+	 *
+	 * @return array
+	 */
+	private function get_woocommerce_memberships_options() {
+		// Check if WooCommerce Memberships is active.
+		if ( ! class_exists( 'WC_Memberships' ) ) {
+			return [];
+		}
+
+		// Fetch WooCommerce Membership Plans.
+		$memberships = wc_memberships_get_membership_plans();
+
+		// Prepare the options array.
+		$options = [];
+		foreach ( $memberships as $membership ) {
+			$options[ $membership->get_id() ] = $membership->get_name();
+		}
+
+		return $options;
+	}
+
+	/**
+	 * Enqueue the tab scripts.
+	 *
+	 * @param string $hook The current page hook.
+	 */
+	public static function enqueue_tab_scripts( $hook ) {
+		// Get the current tab.
+		$current_tab = isset( $_GET['tab'] ) ? sanitize_text_field( wp_unslash( $_GET['tab'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		// Get path to src directory.
+		$src_dir = plugins_url( 'src/js/access-settings.js', NEWSPACK_TECNAVIA_INTEGRATION_PLUGIN_FILE );
+
+		// Enqueue the script only on the Newspack-Tecnavia settings tab.
+		if (
+			'woocommerce_page_wc-settings' === $hook &&
+			! empty( $current_tab )
+			&& self::NEWSPACK_TECNAVIA_SETTINGS_TAB === $current_tab
+		) {
+			wp_enqueue_script(
+				'newspack-tecnavia-integration-admin',
+				$src_dir,
+				[],
+				self::NEWSPACK_TECNAVIA_ASSETS_VERSION,
+				true
+			);
+		}
 	}
 }

--- a/includes/woocommerce/class-wc-settings-option-tab.php
+++ b/includes/woocommerce/class-wc-settings-option-tab.php
@@ -25,6 +25,13 @@ class WC_Settings_Option_Tab extends WC_Settings_Page {
 	private $e_edition_endpoint_url_option;
 
 	/**
+	 * Newspack Tecnavia Integration e-edition endpoint link label.
+	 *
+	 * @var string
+	 */
+	private $e_edition_endpoint_link_label;
+
+	/**
 	 * Newspack Tecnavia Integration Tecnavia URL.
 	 *
 	 * @var string
@@ -36,12 +43,14 @@ class WC_Settings_Option_Tab extends WC_Settings_Page {
 	 *
 	 * @param string $e_edition_endpoint_url_option e-edition endpoint URL option name.
 	 * @param string $technavia_url_option Tecnavia URL option name.
+	 * @param string $e_edition_endpoint_link_label e-edition endpoint link label option name.
 	 */
-	public function __construct( $e_edition_endpoint_url_option, $technavia_url_option ) {
+	public function __construct( $e_edition_endpoint_url_option, $technavia_url_option, $e_edition_endpoint_link_label ) {
 		/**
 		 * Initialize constants.
 		 */
 		$this->e_edition_endpoint_url_option = $e_edition_endpoint_url_option;
+		$this->e_edition_endpoint_link_label = $e_edition_endpoint_link_label;
 		$this->technavia_url_option          = $technavia_url_option;
 
 		/**
@@ -88,6 +97,14 @@ class WC_Settings_Option_Tab extends WC_Settings_Page {
 				'desc_tip' => true,
 				'id'       => $this->e_edition_endpoint_url_option,
 				'css'      => 'min-width:600px;',
+			),
+			array(
+				'title'    => __( 'E-edition Endpoint Link Label', 'newspack-tecnavia-integration' ),
+				'type'     => 'text',
+				'desc'     => __( 'Add the label for the e-edition endpoint link.', 'newspack-tecnavia-integration' ),
+				'desc_tip' => true,
+				'id'       => $this->e_edition_endpoint_link_label,
+				'css'      => 'min-width:300px;',
 			),
 			array(
 				'title'    => __( 'Tecnavia URL', 'newspack-tecnavia-integration' ),

--- a/includes/woocommerce/class-wc-settings-option-tab.php
+++ b/includes/woocommerce/class-wc-settings-option-tab.php
@@ -125,10 +125,10 @@ class WC_Settings_Option_Tab extends WC_Settings_Page {
 		 * Ids are constructed to be used as array keys in the permissions option.
 		 * It will store the access settings as an array under a single option ( $tecnavia_permissions_option ).
 		 */
-		$all_registered_users_id  = $this->tecnavia_permissions_option . '[' . Settings::ALL_REGISTERED_USERS_ACCESS_KEY . ']';
-		$allowed_roles_id         = $this->tecnavia_permissions_option . '[' . Settings::ALLOWED_ROLES_ACCESS_KEY . ']';
-		$allowed_subscription_id  = $this->tecnavia_permissions_option . '[' . Settings::ALLOWED_SUBSCRIPTIONS_ACCESS_KEY . ']';
-		$allowed_memberships_id   = $this->tecnavia_permissions_option . '[' . Settings::ALLOWED_MEMBERSHIPS_ACCESS_KEY . ']';
+		$all_registered_users_id  = sprintf( '%s[%s]', $this->tecnavia_permissions_option, Settings::ALL_REGISTERED_USERS_ACCESS_KEY );
+		$allowed_roles_id         = sprintf( '%s[%s]', $this->tecnavia_permissions_option, Settings::ALLOWED_ROLES_ACCESS_KEY );
+		$allowed_subscription_id  = sprintf( '%s[%s]', $this->tecnavia_permissions_option, Settings::ALLOWED_SUBSCRIPTIONS_ACCESS_KEY );
+		$allowed_memberships_id   = sprintf( '%s[%s]', $this->tecnavia_permissions_option, Settings::ALLOWED_MEMBERSHIPS_ACCESS_KEY );
 
 		/**
 		 * Settings for the Tecnavia Integration

--- a/src/js/access-settings.js
+++ b/src/js/access-settings.js
@@ -1,0 +1,71 @@
+/**
+ * Newspack Tecnavia Integration Access Settings  toggle JS.
+ *
+ * Adds script to handle the toggling of dependency-dependent elements.
+ * Basically, based on the state of a dependency checkbox element
+ * it will enable or disable the dependent elements.
+ *
+ * @link   https://www.newspack.com
+ * @file   This files defines the JS script to handle the toggling of dependent elements.
+ * @author Automattic
+ * @since  1.0
+ */
+
+/**
+ * Toggles the dependent elements based on the state of the dependency element.
+ *
+ * @param {HTMLElement} dependencyElementCheckbox The dependency element.
+ * @param {NodeList} dependentElements The dependent elements.
+ *
+ * @return void
+ */
+function toggleDependentElements ( dependencyElementCheckbox, dependentElements ) {
+	// Loop through the dependent elements.
+	dependentElements.forEach( ( element ) => {
+		// Get the dependency element on which the element is dependent.
+		const dependencyElement = element.getAttribute("data-dependent-on");
+
+		// Check only for the elements that are dependent on the dependencyElement.
+		if ( dependencyElement !== dependencyElementCheckbox.id ) {
+			// Skip this iteration.
+			return;
+		}
+
+		// If the checkbox is checked, disable the dependent elements.
+		if ( ! dependencyElementCheckbox.checked ) {
+			element.removeAttribute("disabled");
+		} else {
+			element.setAttribute("disabled", true);
+		}
+	});
+};
+
+/**
+ * Initialize the script.
+ */
+function init() {
+	// Get the checkbox element.
+	const dependencyElementCheckbox = document.querySelector(
+		'input[data-dependency="1"]'
+	);
+
+	// Elements that have 'data-dependent-on' attribute.
+	const dependentElements = document.querySelectorAll(
+		'[data-dependent-on]'
+	);
+
+	// Check if the elements exist.
+	if ( ! dependencyElementCheckbox || dependentElements.length === 0 ) {
+		console.warn( "Newspack Tecnavia integration : Dependency checkbox or dependent elements not found." );
+		return;
+	}
+
+	// Run the function on page load.
+	toggleDependentElements( dependencyElementCheckbox, dependentElements );
+
+	// Toggle on change.
+	dependencyElementCheckbox.addEventListener( "change", () => { toggleDependentElements( dependencyElementCheckbox, dependentElements ); } );
+}
+
+// Run the script on DOMContentLoaded.
+document.addEventListener( 'DOMContentLoaded', init );


### PR DESCRIPTION
## Changes:
1. Initializer Updates: Modified Initializer::init() to check for valid dependencies before initializing the Settings class.

2. New Settings Class: Created a Settings class to manage Tecnavia-specific configurations. Fields:
    - E_EDITION_ENDPOINT_URL_OPTION: the e-edition endpoint.
    - E_EDITION_ENDPOINT_LINK_LABEL: Label for the e-edition link in WooCommerce account menu.
    - TECNAVIA_URL_OPTION: URL for the Tecnavia service.
    - FALLBACK_PAGE_ID_OPTION: ID of the fallback page.

3. WooCommerce Integration:
    - Adds a settings tab in WC settings for Tecnavia Integration.
    - Adds a custom endpoint (e-edition) to My Account menu.

4. Settings Tab: Added WC_Settings_Option_Tab class to register Tecnavia settings within WooCommerce.
      - Fields for configuring the endpoint URL, link label, Tecnavia URL, and fallback page.
      - Logic to display and save the settings via WooCommerce's admin interface.
      - Settings to configure the WC Subscription/Membership/Role for tecnavia access.

## Testing:

1. Navigate to WooCommerce > Settings and verify the new "Newspack Tecnavia Integration" tab is added.
2. Configure the e-edition URL, link label, Tecnavia URL, and fallback page, and save the changes.
3. Check the WooCommerce account menu for the "e-edition" link.
4. Test the Tecnavia access settings by setting the All registered users checkboc to true. It won't allow to set any other settings/freeze already set settings and ignore them when saving.
5. Multi selects on Roles, Subscription Products & Memberships.

## Demo:

https://github.com/user-attachments/assets/c2b4f7b1-7b0f-4a00-8203-f651fc5ecfe6

