### PR TITLE
fix(rest-controller): Output raw XML data

### DIFF
--- a/includes/class-rest-controller.php
+++ b/includes/class-rest-controller.php
@@ -76,7 +76,8 @@ class REST_Controller {
 		$server->send_header( 'Content-Type', 'text/xml' );
 
 		// Directly output the XML to skip the JSON encoding.
-		echo esc_xml( $result->data );
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $result->data;
 
 		return true;
 	}


### PR DESCRIPTION
# Issue
XML response is being escaped.

```
&lt;?xml version=&quot;1.0&quot;?&gt;&lt;LOGIN&gt;&lt;TOKEN&gt;qwertyuiopsdfghjklzxcvbnm&lt;/TOKEN&gt;&lt;UNIQUE_USER_ID&gt;admin-newspack&lt;/UNIQUE_USER_ID&gt;&lt;EMAIL&gt;admin-newspack@automattic.com&lt;/EMAIL&gt;&lt;USER_NAME&gt;admin-newspack&lt;/USER_NAME&gt;&lt;IS_LOGGED&gt;Yes&lt;/IS_LOGGED&gt;&lt;FOD&gt;1111111&lt;/FOD&gt;&lt;/LOGIN&gt;
```

# Changes 📝
Modify the following class-rest-controller file:- 
- Remove the XML response encoding in the REST controller to prevent this issue.

## Related
[Asana Ref Link](https://app.asana.com/0/0/1208959720314064/1209438962789548/f)
