### PR TITLE
Don't use redirect in My Account section

### DIFF
--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -81,6 +81,10 @@ class Settings {
 	 * @return array
 	 */
 	public static function add_wc_account_menu_item( $items ) {
+		if ( ! User::check_user_tecnavia_access( get_current_user_id() ) ) {
+			return $items;
+		}
+
 		// Create the e-edition link.
 		$e_edition_link = array(
 			'e-edition' => self::get_e_edition_endpoint_link_label(),
@@ -106,6 +110,8 @@ class Settings {
 		if ( $endpoint !== 'e-edition' ) {
 			return $url;
 		}
+
+		return User::get_user_tecnavia_url( get_current_user_id() );
 
 		// Get the e-edition URL.
 		$e_edition_url = self::get_e_edition_endpoint_url();


### PR DESCRIPTION
This PR simplifies the handling of e-edition links in My Account. Instead of redirecting from the site, it directly outputs the e-edition link if the user has access to e-editions. The main reason for this is to avoid possible caching of the redirect, which seems to maybe cause problems since people get a cached (invalid) redirect when clicking the link. I'm running it for a while to see how I feel about it, then maybe we should make this the default behavior.